### PR TITLE
Allow building with stack on NixOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,3 +7,7 @@ packages:
 flags:
   proteaaudio:
     example: true
+nix:
+  enable: false
+  packages: [pulseaudio]
+  pure: false


### PR DESCRIPTION
This allows building with `stack --nix build` and runs without error.